### PR TITLE
feat: 推し活費用トラッカー機能を追加

### DIFF
--- a/example1/CLAUDE.md
+++ b/example1/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md — example1
+
+Next.js 16ハンズオン用プロジェクト。Claude Codeでの開発を支援するため、このファイルに開発ガイドを記述しています。
+
+## プロジェクト概要
+
+- **フレームワーク**: Next.js 16 (App Router / Turbopack)
+- **言語**: TypeScript 5
+- **テスト**: Vitest 4
+- **リンター**: ESLint 9
+
+## ディレクトリ構成
+
+```
+example1/
+├── src/
+│   ├── app/                 # App Router
+│   │   ├── api/health/      # ヘルスチェックAPI (route.ts)
+│   │   ├── layout.tsx       # ルートレイアウト
+│   │   ├── page.tsx         # ホームページ
+│   │   ├── page.module.css
+│   │   └── globals.css
+│   └── lib/
+│       └── types.ts         # 共有型定義
+├── public/                  # 静的ファイル
+├── vitest.config.ts         # Vitestテスト設定
+├── next.config.ts           # Next.js設定
+├── eslint.config.mjs        # ESLint設定
+├── tsconfig.json            # TypeScript設定
+└── package.json
+```
+
+## 開発コマンド
+
+```bash
+# 開発サーバー起動（Turbopack）
+npm run dev
+
+# ビルド
+npm run build
+
+# 本番サーバー起動
+npm start
+
+# リント実行
+npm run lint
+
+# テスト実行
+npm run test              # 1回実行
+npm run test:watch        # 監視モード
+npm run test:ui           # Vitest UI
+npm run test:coverage     # カバレッジ計測
+```
+
+## 重要な注意点
+
+### TypeScript
+
+- すべてのコンポーネント・関数は型安全性を確保する
+- `src/lib/types.ts` に共有型を集約
+
+### App Router
+
+- `src/app/` 配下のディレクトリ構造 = ルーティング
+- `page.tsx` がページコンポーネント、`route.ts` がAPIハンドラ
+- デフォルトではServer Components
+
+### テスト（Vitest）
+
+- `src/app/api/health/` に `route.test.ts` として配置
+- happy-dom環境でブラウザAPIをシミュレート
+- カバレッジは `@vitest/coverage-v8` で計測
+
+## 出力言語
+
+**日本語で出力すること** - すべての説明・コメント・提案は日本語で記述
+
+## 関連タスク
+
+親ディレクトリの `../issues/task*.md` を参照して段階的に学習してください。
+
+- task1〜task3: Claude Code基本
+- task5〜task6: Skills・サブエージェント
+- task7: ペアプログラミング（新機能実装）
+- task9: Vitestでテスト作成

--- a/example1/src/app/oshi/_components/OshiTracker.tsx
+++ b/example1/src/app/oshi/_components/OshiTracker.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { calcDailyTotal, calcMonthlyTotal, calcYearlyTotal, formatCurrency } from "@/lib/expenses";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import type { OshiExpense, OshiExpenseCategory } from "@/lib/types";
+import styles from "../oshi.module.css";
+
+const CATEGORIES: OshiExpenseCategory[] = ["グッズ", "遠征", "配信", "その他"];
+
+interface FormState {
+  date: string;
+  amount: string;
+  category: OshiExpenseCategory;
+  oshi: string;
+  memo: string;
+}
+
+const baseForm: Omit<FormState, "date"> = {
+  amount: "",
+  category: "グッズ",
+  oshi: "",
+  memo: "",
+};
+
+export default function OshiTracker() {
+  const [expenses, setExpenses] = useLocalStorage<OshiExpense[]>("oshi-expenses", []);
+  const [form, setForm] = useState<FormState>(() => ({
+    ...baseForm,
+    date: new Date().toISOString().slice(0, 10),
+  }));
+  const [error, setError] = useState("");
+  const [filterOshi, setFilterOshi] = useState<string | null>(null);
+
+  const { today, thisMonth, thisYear } = useMemo(() => {
+    const d = new Date().toISOString().slice(0, 10);
+    return { today: d, thisMonth: d.slice(0, 7), thisYear: d.slice(0, 4) };
+  }, []);
+
+  const oshiNames = useMemo(
+    () => [...new Set(expenses.map((e) => e.oshi))].sort(),
+    [expenses]
+  );
+
+  const filteredExpenses = useMemo(
+    () => (filterOshi ? expenses.filter((e) => e.oshi === filterOshi) : expenses),
+    [expenses, filterOshi]
+  );
+
+  const dailyTotal = useMemo(() => calcDailyTotal(filteredExpenses, today), [filteredExpenses, today]);
+  const monthlyTotal = useMemo(() => calcMonthlyTotal(filteredExpenses, thisMonth), [filteredExpenses, thisMonth]);
+  const yearlyTotal = useMemo(() => calcYearlyTotal(filteredExpenses, thisYear), [filteredExpenses, thisYear]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.oshi.trim()) {
+      setError("推しの名前を入力してください");
+      return;
+    }
+    const amount = Number(form.amount);
+    if (!amount || amount <= 0) {
+      setError("金額を正しく入力してください");
+      return;
+    }
+    setError("");
+    const newExpense: OshiExpense = {
+      id: crypto.randomUUID(),
+      date: form.date,
+      amount,
+      category: form.category,
+      oshi: form.oshi.trim(),
+      memo: form.memo.trim() || undefined,
+    };
+    setExpenses((prev) => [newExpense, ...prev]);
+    setForm({ ...baseForm, date: new Date().toISOString().slice(0, 10) });
+  }
+
+  function handleDelete(id: string) {
+    setExpenses((prev) => prev.filter((e) => e.id !== id));
+  }
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>推し活費用トラッカー</h1>
+
+      {/* 集計カード */}
+      <div className={styles.summaryGrid}>
+        <div className={styles.summaryCard}>
+          <p className={styles.summaryLabel}>今日</p>
+          <p className={styles.summaryAmount}>{formatCurrency(dailyTotal)}</p>
+        </div>
+        <div className={styles.summaryCard}>
+          <p className={styles.summaryLabel}>今月</p>
+          <p className={styles.summaryAmount}>{formatCurrency(monthlyTotal)}</p>
+        </div>
+        <div className={styles.summaryCard}>
+          <p className={styles.summaryLabel}>今年</p>
+          <p className={styles.summaryAmount}>{formatCurrency(yearlyTotal)}</p>
+        </div>
+      </div>
+
+      {/* 入力フォーム */}
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <h2 className={styles.formTitle}>費用を記録する</h2>
+        {error && <p className={styles.error}>{error}</p>}
+        <div className={styles.formRow}>
+          <label className={styles.label}>
+            日付
+            <input
+              type="date"
+              className={styles.input}
+              value={form.date}
+              onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}
+              required
+            />
+          </label>
+          <label className={styles.label}>
+            金額（円）
+            <input
+              type="number"
+              className={styles.input}
+              placeholder="例: 3000"
+              value={form.amount}
+              min={1}
+              onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
+              required
+            />
+          </label>
+        </div>
+        <div className={styles.formRow}>
+          <label className={styles.label}>
+            推し
+            <input
+              type="text"
+              className={styles.input}
+              placeholder="推しの名前"
+              value={form.oshi}
+              onChange={(e) => setForm((f) => ({ ...f, oshi: e.target.value }))}
+              required
+            />
+          </label>
+          <label className={styles.label}>
+            カテゴリ
+            <select
+              className={styles.input}
+              value={form.category}
+              onChange={(e) => setForm((f) => ({ ...f, category: e.target.value as OshiExpenseCategory }))}
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <label className={styles.label}>
+          メモ（任意）
+          <input
+            type="text"
+            className={styles.input}
+            placeholder="例: ライブBD"
+            value={form.memo}
+            onChange={(e) => setForm((f) => ({ ...f, memo: e.target.value }))}
+          />
+        </label>
+        <button type="submit" className={styles.button}>追加する</button>
+      </form>
+
+      {/* 推しフィルター */}
+      <div className={styles.filterTabs}>
+        <button
+          className={filterOshi === null ? styles.filterTabActive : styles.filterTab}
+          onClick={() => setFilterOshi(null)}
+        >
+          すべて
+        </button>
+        {oshiNames.map((name) => (
+          <button
+            key={name}
+            className={filterOshi === name ? styles.filterTabActive : styles.filterTab}
+            onClick={() => setFilterOshi(name)}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+
+      {/* 履歴一覧 */}
+      <section className={styles.listSection}>
+        <h2 className={styles.formTitle}>
+          履歴{filterOshi ? `（${filterOshi}）` : ""}
+        </h2>
+        {filteredExpenses.length === 0 ? (
+          <p className={styles.empty}>まだ記録がありません</p>
+        ) : (
+          <ul className={styles.list}>
+            {filteredExpenses.map((expense) => (
+              <li key={expense.id} className={styles.listItem}>
+                <div className={styles.listItemInfo}>
+                  <span className={styles.listItemDate}>{expense.date}</span>
+                  <span className={styles.badge}>{expense.category}</span>
+                  <span className={styles.listItemOshi}>{expense.oshi}</span>
+                  {expense.memo && <span className={styles.listItemMemo}>— {expense.memo}</span>}
+                </div>
+                <div className={styles.listItemRight}>
+                  <span className={styles.listItemAmount}>{formatCurrency(expense.amount)}</span>
+                  <button
+                    onClick={() => handleDelete(expense.id)}
+                    className={styles.deleteButton}
+                    aria-label="削除"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/example1/src/app/oshi/oshi.module.css
+++ b/example1/src/app/oshi/oshi.module.css
@@ -1,0 +1,253 @@
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.title {
+  font-size: 1.75rem;
+  font-weight: bold;
+  margin-bottom: 1.5rem;
+  color: #171717;
+}
+
+/* 集計カード */
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.summaryCard {
+  background: #f5f0ff;
+  border: 1px solid #c4b5fd;
+  border-radius: 12px;
+  padding: 1.25rem;
+  text-align: center;
+}
+
+.summaryLabel {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
+}
+
+.summaryAmount {
+  font-size: 1.4rem;
+  font-weight: bold;
+  color: #7c3aed;
+}
+
+/* フォーム */
+.form {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.formTitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #374151;
+  font-weight: 500;
+}
+
+.input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  color: #111827;
+  background: #f9fafb;
+  transition: border-color 0.15s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #7c3aed;
+  background: #ffffff;
+}
+
+.button {
+  align-self: flex-start;
+  padding: 0.65rem 1.5rem;
+  background: #7c3aed;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.button:hover {
+  background: #6d28d9;
+}
+
+.error {
+  color: #dc2626;
+  font-size: 0.85rem;
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}
+
+/* 履歴リスト */
+.listSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.listItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  gap: 0.5rem;
+}
+
+.listItemInfo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.listItemDate {
+  font-size: 0.8rem;
+  color: #6b7280;
+  min-width: 90px;
+}
+
+.badge {
+  font-size: 0.75rem;
+  background: #ede9fe;
+  color: #7c3aed;
+  padding: 0.2rem 0.5rem;
+  border-radius: 99px;
+  font-weight: 500;
+}
+
+.listItemOshi {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #111827;
+}
+
+.listItemMemo {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.listItemRight {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.listItemAmount {
+  font-weight: bold;
+  color: #7c3aed;
+  white-space: nowrap;
+}
+
+.deleteButton {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.deleteButton:hover {
+  color: #dc2626;
+  background: #fef2f2;
+}
+
+.empty {
+  color: #9ca3af;
+  font-size: 0.9rem;
+  padding: 1rem 0;
+}
+
+/* フィルタータブ */
+.filterTabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.filterTab {
+  padding: 0.4rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 99px;
+  background: #ffffff;
+  color: #374151;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.filterTab:hover {
+  border-color: #7c3aed;
+  color: #7c3aed;
+}
+
+.filterTabActive {
+  padding: 0.4rem 1rem;
+  border: 1px solid #7c3aed;
+  border-radius: 99px;
+  background: #7c3aed;
+  color: #ffffff;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+@media (max-width: 480px) {
+  .summaryGrid {
+    grid-template-columns: 1fr;
+  }
+  .formRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/example1/src/app/oshi/page.tsx
+++ b/example1/src/app/oshi/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import OshiTracker from "./_components/OshiTracker";
+
+export const metadata: Metadata = {
+  title: "推し活費用トラッカー",
+};
+
+export default function OshiPage() {
+  return <OshiTracker />;
+}

--- a/example1/src/hooks/useLocalStorage.ts
+++ b/example1/src/hooks/useLocalStorage.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === "undefined") return initialValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ストレージ容量超過またはプライベートモード時は無視
+    }
+  }, [key, value]);
+
+  const setStoredValue = useCallback((newValue: T | ((prev: T) => T)) => {
+    setValue(newValue);
+  }, []);
+
+  return [value, setStoredValue] as const;
+}

--- a/example1/src/lib/expenses.ts
+++ b/example1/src/lib/expenses.ts
@@ -1,0 +1,23 @@
+import type { OshiExpense } from "./types";
+
+export function calcDailyTotal(expenses: OshiExpense[], date: string): number {
+  return expenses
+    .filter((e) => e.date === date)
+    .reduce((sum, e) => sum + e.amount, 0);
+}
+
+export function calcMonthlyTotal(expenses: OshiExpense[], yearMonth: string): number {
+  return expenses
+    .filter((e) => e.date.startsWith(yearMonth))
+    .reduce((sum, e) => sum + e.amount, 0);
+}
+
+export function calcYearlyTotal(expenses: OshiExpense[], year: string): number {
+  return expenses
+    .filter((e) => e.date.startsWith(year))
+    .reduce((sum, e) => sum + e.amount, 0);
+}
+
+export function formatCurrency(amount: number): string {
+  return amount.toLocaleString("ja-JP") + "円";
+}

--- a/example1/src/lib/types.ts
+++ b/example1/src/lib/types.ts
@@ -29,3 +29,14 @@ export interface HealthCheckResponse {
   status: "ok";
   timestamp: string;
 }
+
+export type OshiExpenseCategory = "グッズ" | "遠征" | "配信" | "その他";
+
+export interface OshiExpense {
+  id: string;
+  date: string; // ISO 8601 "YYYY-MM-DD"
+  amount: number;
+  category: OshiExpenseCategory;
+  oshi: string;
+  memo?: string;
+}


### PR DESCRIPTION
- /oshi ページに費用の記録・集計・削除機能を実装
- 日・月・年単位の合計金額を表示
- 推し名でフィルタリングするタブ機能を追加
- useLocalStorageカスタムフックによるブラウザ永続化
- OshiExpense型・集計純粋関数をlib配下に追加